### PR TITLE
Add partner components and data

### DIFF
--- a/src/assets/partners/apisfirst.svg
+++ b/src/assets/partners/apisfirst.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="80" viewBox="0 0 200 80">
+  <rect width="200" height="80" fill="#d7ffd7"/>
+  <text x="100" y="50" font-size="24" text-anchor="middle" fill="#000">APIsFirst</text>
+</svg>

--- a/src/assets/partners/codecentric.svg
+++ b/src/assets/partners/codecentric.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="80" viewBox="0 0 200 80">
+  <rect width="200" height="80" fill="#ffd7d7"/>
+  <text x="100" y="50" font-size="24" text-anchor="middle" fill="#000">Codecentric</text>
+</svg>

--- a/src/assets/partners/konneqt.svg
+++ b/src/assets/partners/konneqt.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="80" viewBox="0 0 200 80">
+  <rect width="200" height="80" fill="#d7d7ff"/>
+  <text x="100" y="50" font-size="24" text-anchor="middle" fill="#000">Konneqt</text>
+</svg>

--- a/src/assets/partners/osaango.svg
+++ b/src/assets/partners/osaango.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="80" viewBox="0 0 200 80">
+  <rect width="200" height="80" fill="#e0e0e0"/>
+  <text x="100" y="50" font-size="24" text-anchor="middle" fill="#000">Osaango</text>
+</svg>

--- a/src/components/PartnerCard.astro
+++ b/src/components/PartnerCard.astro
@@ -1,0 +1,16 @@
+---
+interface Props {
+  title: string;
+  href: string;
+  logo: string;
+  description: string;
+}
+
+const { title, href, logo, description } = Astro.props as Props;
+---
+
+<a href={href} class="card flex flex-col items-center text-center p-4 gap-2">
+  <img src={logo} alt={`${title} logo`} class="h-16 w-auto" loading="lazy" />
+  <h3 class="text-lg font-semibold">{title}</h3>
+  <p class="text-sm">{description}</p>
+</a>

--- a/src/components/PartnerGrid.astro
+++ b/src/components/PartnerGrid.astro
@@ -1,0 +1,19 @@
+---
+import PartnerCard from './PartnerCard.astro';
+interface Partner {
+  title: string;
+  href: string;
+  logo: string;
+  description: string;
+}
+interface Props {
+  partners: Partner[];
+}
+const { partners } = Astro.props as Props;
+---
+
+<div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+  {partners.map(partner => (
+    <PartnerCard {...partner} />
+  ))}
+</div>

--- a/src/content/docs/community/index.md
+++ b/src/content/docs/community/index.md
@@ -8,10 +8,10 @@ draft: false
 
 **Our current partners:**
 
-* **Osaango** (https://www.osaango.com) – Coordinates the global APIOps Cycles community and method development. Osaango provides API & Agile consulting, coaching and training. If you are interested in API strategies, development guidelines or training made to work for your organization contact us. 
-* **Codecentric** (https://www.codecentric.de/) – Provides expert content, consulting, and promotes the method in the DACH region
-* **APIsFirst** (https://www.apisfirst.com) - Provides expert content, consulting, and promotes the method globally, specifically in UK and Australia
-* **Konneqt** ([formerly QriarLabs](https://qriarlabs.com/qap-canvas/)) – Based in Brazil, operatest globally. Offers advanced API + integration platforms and supports QAP Canvas tool development, which uses some of the APIOps Cycles canvases to automate creating APIs.
+import PartnerGrid from '../../../components/PartnerGrid.astro';
+import partners from '../../../data/partners.json';
+
+<PartnerGrid partners={partners} />
 
 ### Partner with Us to Evolve the APIOps Cycles Method
 

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -27,19 +27,7 @@ hero:
       variant: secondary
 ---
 
-import { Card, CardGrid } from '@astrojs/starlight/components';
+import PartnerGrid from '../../components/PartnerGrid.astro';
+import partners from '../../data/partners.json';
 
-<CardGrid>
-  <Card title="Osaango" icon="open-book">
-    Interesting content you want to highlight.
-  </Card>
-  <Card title="Codecentric AG" icon="information">
-    More information you want to share.
-  </Card>
-  <Card title="APIsFirst Ltd" icon="information">
-    More information you want to share.
-  </Card>
-   <Card title="Konnect" icon="information">
-    More information you want to share.
-  </Card>
-</CardGrid>
+<PartnerGrid partners={partners} />

--- a/src/data/partners.json
+++ b/src/data/partners.json
@@ -1,0 +1,26 @@
+[
+  {
+    "title": "Osaango",
+    "href": "https://www.osaango.com",
+    "logo": "/assets/partners/osaango.svg",
+    "description": "Coordinates the global APIOps Cycles community and method development."
+  },
+  {
+    "title": "Codecentric",
+    "href": "https://www.codecentric.de/",
+    "logo": "/assets/partners/codecentric.svg",
+    "description": "Provides expert content, consulting, and promotes the method in the DACH region."
+  },
+  {
+    "title": "APIsFirst",
+    "href": "https://www.apisfirst.com",
+    "logo": "/assets/partners/apisfirst.svg",
+    "description": "Provides expert content, consulting, and promotes the method globally."
+  },
+  {
+    "title": "Konneqt",
+    "href": "https://qriarlabs.com/qap-canvas/",
+    "logo": "/assets/partners/konneqt.svg",
+    "description": "Offers advanced API and integration platforms and supports QAP Canvas development."
+  }
+]


### PR DESCRIPTION
## Summary
- add PartnerCard & PartnerGrid components
- add placeholder partner logos and partners.json data
- display PartnerGrid on homepage and community page

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6884e5d11174832cb658dbda7ea20171