### PR TITLE
Add CanvasCreator component

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ Install dependencies once with:
 npm install
 ```
 
+### Canvas editor
+
+Interactive canvases on the site are powered by the [Canvas Creator](https://canvascreator.apiopscycles.com) tool. The component is installed from npm so make sure to run `npm install` before building or running the dev server.
+
 ## Local development
 
 Run a local dev server:

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "json-autotranslate": "^1.16.1",
     "sharp": "^0.34.2",
     "tailwindcss": "^4.1.11",
-    "unplugin-icons": "^22.1.0"
+    "unplugin-icons": "^22.1.0",
+    "canvascreator": "^1.0.0"
   },
   "engines": {
     "node": ">=22"

--- a/scripts/generate-method-pages.mjs
+++ b/scripts/generate-method-pages.mjs
@@ -164,7 +164,12 @@ function stationBody(data, resources, labels = baseLabels, locale = '') {
 }
 
 async function resourceBody(res, labels = baseLabels, locale = '') {
-  let out = "import { Aside } from '@astrojs/starlight/components';\n\n";
+  let out = "import { Aside } from '@astrojs/starlight/components';\n";
+  if (res.category === 'canvas') {
+    const prefix = locale ? '../../../components' : '../../components';
+    out += `import CanvasCreator from '${prefix}/CanvasCreator.astro';\n`;
+  }
+  out += "\n";
   if (res.description) out += `${translate(res.description, labels)}\n\n`;
   if (Array.isArray(res.outcomes) && res.outcomes.length) {
     out += `## ${t('outcomes', labels)}\n\n`;
@@ -234,9 +239,12 @@ async function resourceBody(res, labels = baseLabels, locale = '') {
     try {
       const snippetContent = await fsPromises.readFile(snippetPath, 'utf8');
       out += '\n\n' + snippetContent.trim();
-    } catch {
+  } catch {
       console.warn(`Snippet file not found: ${snippetPath}`);
     }
+  }
+  if (res.category === 'canvas') {
+    out += `\n\n<CanvasCreator canvasId="${res.id}" />`;
   }
   return out.trim();
 }

--- a/src/components/CanvasCreator.astro
+++ b/src/components/CanvasCreator.astro
@@ -1,0 +1,14 @@
+---
+interface Props {
+  canvasId: string;
+}
+
+const { canvasId } = Astro.props as Props;
+const clientAddress = Astro.clientAddress;
+---
+
+<div id={canvasId}></div>
+<script define:vars={{ canvasId, clientAddress }} type="module" client:load>
+  import canvascreator from 'canvascreator';
+  canvascreator.initialize({ canvasId, clientAddress });
+</script>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -10,6 +10,8 @@ export const collections = {
                                 icon: z.string().optional(),
                                 metrolines: z.array(z.string()).optional(),
                                 stations: z.array(z.string()).optional(),
+                                category: z.string().optional(),
+                                canvasId: z.string().optional(),
                         }),
                 }),
         }),


### PR DESCRIPTION
## Summary
- add `canvascreator` dependency
- create `CanvasCreator.astro` with client script for the canvas editor
- inject `<CanvasCreator>` for canvas resources when generating docs
- allow `category` and `canvasId` frontmatter fields
- document canvas editor usage and running `npm install`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6888c0af233c832cbe81b24e0551a687