### PR TITLE
Colorize Metro line steps

### DIFF
--- a/scripts/generate-method-pages.mjs
+++ b/scripts/generate-method-pages.mjs
@@ -321,6 +321,7 @@ function lineBody(
 async function generateIndex(info, folder, locale, labels = baseLabels) {
   const fm = { title: translate(info.title, labels) };
   if (typeof info.order !== 'undefined') fm.sidebar = { order: info.order };
+  if (info.image) fm.image = info.image;
   fm.slug = locale ? `${locale}/${folder}` : folder;
   const dir = locale ? path.join(docsDir, locale, folder) : path.join(docsDir, folder);
   const file = path.join(dir, 'index.mdx');
@@ -540,6 +541,7 @@ async function generateLine(line, stationMap, stationCriteria, criteriaMap, labe
     stations: line.stations,
     slug: baseSlug,
     color: line.color,
+    sidebar: { order: line.order },
   };
   const file = path.join(docsDir, 'lines', `${line.id}.mdx`);
   await writeMarkdown(file, base, lineBody(line, stationMap, stationCriteria, criteriaMap, baseLabels));
@@ -550,6 +552,7 @@ async function generateLine(line, stationMap, stationCriteria, criteriaMap, labe
       stations: line.stations,
       slug: `${locale}/${baseSlug}`,
       color: line.color,
+      sidebar: { order: line.order },
     };
     const dest = path.join(docsDir, locale, 'lines', `${line.id}.mdx`);
     await writeMarkdown(dest, fm, lineBody(line, stationMap, stationCriteria, criteriaMap, labels, locale));

--- a/scripts/generate-method-pages.mjs
+++ b/scripts/generate-method-pages.mjs
@@ -325,7 +325,13 @@ async function generateIndex(info, folder, locale, labels = baseLabels) {
   fm.slug = locale ? `${locale}/${folder}` : folder;
   const dir = locale ? path.join(docsDir, locale, folder) : path.join(docsDir, folder);
   const file = path.join(dir, 'index.mdx');
-  await writeMarkdown(file, fm, translate(info.description || '', labels));
+  let body = translate(info.description || '', labels);
+  if (info.image) {
+    const depth = locale ? 4 : 3;
+    const rel = path.join(...Array(depth).fill('..'), info.image.replace(/^\//, ''));
+    body += `\n\n![Metro Map](${rel})`;
+  }
+  await writeMarkdown(file, fm, body);
 }
 
 async function generate() {

--- a/src/data/method/lines.json
+++ b/src/data/method/lines.json
@@ -10,6 +10,7 @@
         "title": "line.business-opportunities-line.title",
         "slug": "business-opportunities-line",
         "order": 1,
+        "color": "#26b309",
         "description": "line.business-opportunities-line.description",
         "stations": [
           "monitoring-and-improving",
@@ -26,6 +27,7 @@
         "title": "line.platform-architecture-line.title",
         "slug": "platform-architecture-line",
         "order": 2,
+        "color": "#933469",
         "description": "line.platform-architecture-line.description",
         "stations": [
           "api-product-strategy",
@@ -43,6 +45,7 @@
         "title": "line.api-design-line.title",
         "slug": "api-design-line",
         "order": 3,
+        "color": "#FFC647",
         "description": "line.api-design-line.description",
         "stations": [
           "api-platform-architecture",
@@ -56,6 +59,7 @@
         "title": "line.delivery-line.title",
         "slug": "delivery-line",
         "order": 4,
+        "color": "#FFC647",
         "description": "line.delivery-line.description",
         "stations": [
           "api-delivery",
@@ -71,6 +75,7 @@
         "title": "line.publishing-and-adoption-line.title",
         "slug": "publishing-and-adoption-line",
         "order": 5,
+        "color": "#17C6E9",
         "description": "line.publishing-and-adoption-line.description",
         "stations": [
           "api-audit",
@@ -87,6 +92,7 @@
         "title": "line.operating-model-line.title",
         "slug": "operating-model-line",
         "order": 6,
+        "color": "#1a3987",
         "description": "line.operating-model-line.description",
         "stations": [
           "api-product-strategy",

--- a/src/data/method/lines.json
+++ b/src/data/method/lines.json
@@ -3,7 +3,7 @@
     "title": "lines.title",
     "slug": "lines",
     "order": 0,
-    "image": "../../../assets/metro_map.svg",
+    "image": "/assets/metro_map.svg",
     "description": "lines.description",
     "items": [
       {

--- a/src/data/method/lines.json
+++ b/src/data/method/lines.json
@@ -3,6 +3,7 @@
     "title": "lines.title",
     "slug": "lines",
     "order": 0,
+    "image": "../../../assets/metro_map.svg",
     "description": "lines.description",
     "items": [
       {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -83,4 +83,11 @@
       background-color: var(--color-accent-950);
       color: var(--color-gray-100);
     }
+
+  .line-steps > li::before {
+    background-color: var(--line-color);
+  }
+  .line-steps > li::after {
+    background-color: var(--line-color);
+  }
 }


### PR DESCRIPTION
## Summary
- assign colors to each metro line in `lines.json`
- style line steps bullets using new `line-steps` class
- include line color in generated line pages
- list entry criteria for each station on its line page

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_688c51b8e430832ca496517fe1a51c20