### PR TITLE
Fix canvas links and copy resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 
+# copied resources
+public/assets/
+
 
 # environment variables
 .env

--- a/README.md
+++ b/README.md
@@ -27,11 +27,16 @@ Run a local dev server:
 npm run dev
 ```
 
+This command copies the resource files to `public/` so that links to canvas JSON
+files work during development.
+
 Build the production site:
 
 ```bash
 npm run build
 ```
+
+The build script also copies the resource files before generating the site.
 
 Preview the built site:
 

--- a/package.json
+++ b/package.json
@@ -3,14 +3,15 @@
   "type": "module",
   "version": "0.0.1",
   "scripts": {
-    "dev": "astro dev",
-    "start": "astro dev",
-    "build": "npm run generate:method && npm run generate:icons && astro build",
+    "dev": "npm run copy:resources && astro dev",
+    "start": "npm run copy:resources && astro dev",
+    "build": "npm run copy:resources && npm run generate:method && npm run generate:icons && astro build",
     "preview": "astro preview",
     "astro": "astro",
     "generate:method": "node scripts/generate-method-pages.mjs",
     "generate:icons": "node scripts/generate-icon-imports.mjs",
-    "generate:canvases": "node scripts/generate-canvases.mjs"
+    "generate:canvases": "node scripts/generate-canvases.mjs",
+    "copy:resources": "node scripts/copy-resources.mjs"
   },
   "dependencies": {
     "@astrojs/starlight": "^0.35.0",

--- a/scripts/copy-resources.mjs
+++ b/scripts/copy-resources.mjs
@@ -1,0 +1,20 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(__dirname, '..');
+const srcDir = path.join(rootDir, 'src', 'assets', 'resource');
+const destDir = path.join(rootDir, 'public', 'assets', 'resource');
+
+async function copyResources() {
+  await fs.rm(destDir, { recursive: true, force: true });
+  await fs.mkdir(destDir, { recursive: true });
+  await fs.cp(srcDir, destDir, { recursive: true });
+  console.log('Resources copied.');
+}
+
+copyResources().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/generate-method-pages.mjs
+++ b/scripts/generate-method-pages.mjs
@@ -211,15 +211,15 @@ async function resourceBody(res, labels = baseLabels, locale = '') {
     out += `## ${t('how_it_works', labels)}\n\n`;
     if (res.canvas) {
       const prefix = locale ? '../../../../' : '../../../';
-      const baseDir = locale ? path.join('assets/resource', locale) : 'assets/resource';
+      const baseDir = locale ? path.posix.join('assets/resource', locale) : 'assets/resource';
       const fileBase = `Canvas_${res.canvas}`;
       const alt = htmlEncode(translate(res.title, labels));
-      const svg = `${prefix}${path.join(baseDir, fileBase + '.svg')}`;
+      const svg = `${prefix}${path.posix.join(baseDir, fileBase + '.svg')}`;
       out += `![${alt}](${svg})\n\n`;
       const links = [
         `[SVG](${svg})`,
-        `[PNG](${prefix}${path.join(baseDir, fileBase + '.png')})`,
-        `[JSON](${prefix}${path.join(baseDir, fileBase + '.json')})`,
+        `[PNG](${prefix}${path.posix.join(baseDir, fileBase + '.png')})`,
+        `[JSON](${prefix}${path.posix.join(baseDir, fileBase + '.json')})`,
       ].join(' | ');
       out += links + '\n\n';
     } else if (res.image) {
@@ -231,7 +231,7 @@ async function resourceBody(res, labels = baseLabels, locale = '') {
         const locImgPath = path.join(rootDir, 'src/assets/resource', locale, baseImg);
         try {
           await fsPromises.access(locImgPath);
-          img = path.join('assets/resource', locale, baseImg);
+          img = path.posix.join('assets/resource', locale, baseImg);
         } catch {
           // use default image path
         }
@@ -337,7 +337,7 @@ async function generateIndex(info, folder, locale, labels = baseLabels) {
   let body = translate(info.description || '', labels);
   if (info.image) {
     const depth = locale ? 4 : 3;
-    const rel = path.join(...Array(depth).fill('..'), info.image.replace(/^\//, ''));
+    const rel = path.posix.join(...Array(depth).fill('..'), info.image.replace(/^\//, ''));
     body += `\n\n![Metro Map](${rel})`;
   }
   await writeMarkdown(file, fm, body);


### PR DESCRIPTION
## Summary
- ensure Markdown links use forward slashes for canvases
- add script to copy resource files to `public`
- run resource copy during `dev` and `build`
- document copied resources

## Testing
- `npm run build`
- `npm run copy:resources`

------
https://chatgpt.com/codex/tasks/task_b_688cb44631ec832c877ddbdbe58c30d0