### PR TITLE
Add related metrolines section

### DIFF
--- a/src/data/method/de/labels.json
+++ b/src/data/method/de/labels.json
@@ -5,4 +5,5 @@
   "how_it_works": "Wie es funktioniert",
   "steps": "Schritte",
   "apply_in_work": "Bei Ihrer Arbeit anwenden"
+  ,"related_metrolines": "Verwandte U-Bahnlinien"
 }

--- a/src/data/method/en/labels.json
+++ b/src/data/method/en/labels.json
@@ -5,4 +5,5 @@
   "how_it_works": "How it works",
   "steps": "Steps",
   "apply_in_work": "Apply in your work"
+  ,"related_metrolines": "Related metrolines"
 }

--- a/src/data/method/fi/labels.json
+++ b/src/data/method/fi/labels.json
@@ -5,4 +5,5 @@
   "how_it_works": "Näin se toimii",
   "steps": "Portaat",
   "apply_in_work": "Sovella työssäsi"
+  ,"related_metrolines": "Liittyvät metrolinjat"
 }

--- a/src/data/method/fr/labels.json
+++ b/src/data/method/fr/labels.json
@@ -5,4 +5,5 @@
   "how_it_works": "Comment cela fonctionne-t-il ?",
   "steps": "Étapes",
   "apply_in_work": "Appliquer dans votre travail"
+  ,"related_metrolines": "Métrolines connexes"
 }

--- a/src/data/method/pt/labels.json
+++ b/src/data/method/pt/labels.json
@@ -5,4 +5,5 @@
   "how_it_works": "Como funciona",
   "steps": "Passos",
   "apply_in_work": "Aplicar no seu trabalho"
+  ,"related_metrolines": "Linhas de metrô relacionadas"
 }


### PR DESCRIPTION
## Summary
- add `related_metrolines` translations for all locales
- show related metrolines after the Outcomes section
- style metro line links with the line color

## Testing
- `npm run generate:method`

------
https://chatgpt.com/codex/tasks/task_b_688cbd937648832c96f80f15f0953876